### PR TITLE
fixup! tplg2.0: add dmic support

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -64,8 +64,8 @@ Object.Dai {
 		}
 	}
 	DMIC."0" {
-		name NoCodec-1
-		id 1
+		name NoCodec-6
+		id 6
 		index 0
 		num_pdm_active 2
 		Object.Base.hw_config."DMIC0" {
@@ -79,7 +79,7 @@ Object.Dai {
 			copier_type "DMIC"
 			type dai_out
 			direction "capture"
-			stream_name "NoCodec-1"
+			stream_name "NoCodec-6"
 			period_sink_count 2
 			period_source_count 0
 			format s16le


### PR DESCRIPTION
"DMIC01 Pin" is defined with ID 6 in skl_dai[] which is used by
nocodec mode. So NoCodec-6 is for dmic.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>